### PR TITLE
Add initial MCP workflow builder UI

### DIFF
--- a/tactix/public/workflows/sitrep_builder.json
+++ b/tactix/public/workflows/sitrep_builder.json
@@ -1,0 +1,12 @@
+{
+  "name": "sitrep_builder",
+  "nodes": [
+    { "id": "trigger1", "type": "file_watch", "position": { "x": 0, "y": 0 }, "data": { "label": "File Watcher", "config": { "path": "/data/incident" } } },
+    { "id": "agent1", "type": "claude", "position": { "x": 250, "y": 0 }, "data": { "label": "Claude", "config": { "prompt": "Summarize this incident..." } } },
+    { "id": "output1", "type": "write_json", "position": { "x": 500, "y": 0 }, "data": { "label": "Write JSON", "config": { "path": "/output/sitreps" } } }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger1", "target": "agent1" },
+    { "id": "e2", "source": "agent1", "target": "output1" }
+  ]
+}

--- a/tactix/src/components/ExecutionConsole.tsx
+++ b/tactix/src/components/ExecutionConsole.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function ExecutionConsole({ logs }: { logs: string[] }) {
+  return (
+    <div style={{ height: 150, overflow: 'auto', background: '#111', color: '#0f0', padding: 4 }}>
+      {logs.map((l, i) => (
+        <div key={i}>{l}</div>
+      ))}
+    </div>
+  );
+}

--- a/tactix/src/components/NodeConfigPanel.tsx
+++ b/tactix/src/components/NodeConfigPanel.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Node } from 'reactflow';
+import { WorkflowNodeData } from './WorkflowCanvas';
+
+interface Props {
+  node: Node<WorkflowNodeData> | null;
+  onChange: (id: string, data: WorkflowNodeData) => void;
+}
+
+export default function NodeConfigPanel({ node, onChange }: Props) {
+  if (!node) {
+    return <div style={{ width: 200, padding: 10 }}>No node selected</div>;
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    onChange(node.id, { ...node.data, [name]: value });
+  };
+
+  return (
+    <div style={{ width: 200, padding: 10 }}>
+      <div style={{ marginBottom: 8 }}>
+        <label>Name</label>
+        <input
+          name="label"
+          value={node.data.label || ''}
+          onChange={handleChange}
+          style={{ width: '100%' }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/tactix/src/components/NodePalette.tsx
+++ b/tactix/src/components/NodePalette.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+const nodeList = [
+  { type: 'file_watch', label: 'File Watcher' },
+  { type: 'manual_start', label: 'Manual Start' },
+  { type: 'claude', label: 'Claude Agent' },
+  { type: 'codex', label: 'Codex Agent' },
+  { type: 'sop_reasoner', label: 'SOP Reasoner' },
+  { type: 'bundle_injector', label: 'Bundle Injector' },
+  { type: 'data_enricher', label: 'Data Enricher' },
+  { type: 'if', label: 'IF' },
+  { type: 'map', label: 'Map' },
+  { type: 'wait', label: 'Wait' },
+  { type: 'write_json', label: 'Write JSON' },
+  { type: 'push_claude', label: 'Push to Claude' },
+  { type: 'store_sitrep', label: 'Store SITREP' }
+];
+
+export default function NodePalette() {
+  const onDragStart = (event: React.DragEvent, nodeType: string) => {
+    event.dataTransfer.setData('application/reactflow', nodeType);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  return (
+    <aside style={{ width: 200, background: '#f4f4f4', padding: 10, overflowY: 'auto' }}>
+      {nodeList.map(n => (
+        <div key={n.type}
+             style={{ marginBottom: 8, padding: 4, border: '1px solid #ccc', cursor: 'grab' }}
+             onDragStart={e => onDragStart(e, n.type)}
+             draggable>
+          {n.label}
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/tactix/src/components/WorkflowCanvas.tsx
+++ b/tactix/src/components/WorkflowCanvas.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactFlow, { Background, Controls, Connection, Node, Edge } from 'reactflow';
+import 'reactflow/dist/style.css';
+
+export interface WorkflowNodeData {
+  label: string;
+  config?: Record<string, any>;
+}
+
+export interface WorkflowCanvasProps {
+  nodes: Node<WorkflowNodeData>[];
+  edges: Edge[];
+  onNodesChange: any;
+  onEdgesChange: any;
+  onConnect: (connection: Connection) => void;
+  onSelectionChange?: (params: { nodes: Node[] }) => void;
+}
+
+export default function WorkflowCanvas(props: WorkflowCanvasProps) {
+  return (
+    <ReactFlow {...props} fitView>
+      <Background />
+      <Controls />
+    </ReactFlow>
+  );
+}

--- a/tactix/src/lib/WorkflowEngineMock.ts
+++ b/tactix/src/lib/WorkflowEngineMock.ts
@@ -1,0 +1,18 @@
+import { Workflow } from './WorkflowSerializer';
+
+function sleep(ms: number) {
+  return new Promise(res => setTimeout(res, ms));
+}
+
+export async function runWorkflow(
+  flow: Workflow,
+  logger: (msg: string) => void,
+  highlight?: (id: string) => void
+) {
+  for (const node of flow.nodes) {
+    logger(`Executing ${node.id}`);
+    if (highlight) highlight(node.id);
+    await sleep(300);
+  }
+  logger('Workflow complete');
+}

--- a/tactix/src/lib/WorkflowSerializer.ts
+++ b/tactix/src/lib/WorkflowSerializer.ts
@@ -1,0 +1,13 @@
+export interface Workflow {
+  nodes: any[];
+  edges: any[];
+}
+
+export function exportWorkflow(flow: Workflow): string {
+  return JSON.stringify(flow, null, 2);
+}
+
+export async function importWorkflow(file: File): Promise<Workflow> {
+  const text = await file.text();
+  return JSON.parse(text);
+}

--- a/tactix/src/pages/mcp-workflow.tsx
+++ b/tactix/src/pages/mcp-workflow.tsx
@@ -1,0 +1,100 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { ReactFlowProvider, useNodesState, useEdgesState, addEdge, useReactFlow } from 'reactflow';
+import WorkflowCanvas from '../components/WorkflowCanvas';
+import NodePalette from '../components/NodePalette';
+import NodeConfigPanel from '../components/NodeConfigPanel';
+import ExecutionConsole from '../components/ExecutionConsole';
+import { exportWorkflow, importWorkflow } from '../lib/WorkflowSerializer';
+import { runWorkflow } from '../lib/WorkflowEngineMock';
+
+function WorkflowEditor() {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [selected, setSelected] = useState<any>(null);
+  const [logs, setLogs] = useState<string[]>([]);
+  const { project } = useReactFlow();
+
+  const onConnect = useCallback((connection) => setEdges((eds) => addEdge(connection, eds)), [setEdges]);
+
+  const onDrop = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+    const type = event.dataTransfer.getData('application/reactflow');
+    if (!type) return;
+    const position = project({ x: event.clientX, y: event.clientY });
+    const newNode = { id: `${type}_${nodes.length}`, type: 'default', position, data: { label: type } };
+    setNodes((nds) => nds.concat(newNode));
+  }, [project, nodes, setNodes]);
+
+  const onDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+  }, []);
+
+  const onSelectionChange = useCallback((params: { nodes: any[] }) => {
+    setSelected(params.nodes[0] || null);
+  }, []);
+
+  const updateNode = (id: string, data: any) => {
+    setNodes(nds => nds.map(n => n.id === id ? { ...n, data } : n));
+  };
+
+  const handleExport = () => {
+    const json = exportWorkflow({ nodes, edges });
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'workflow.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const flow = await importWorkflow(file);
+    setNodes(flow.nodes || []);
+    setEdges(flow.edges || []);
+  };
+
+  const handleRun = async () => {
+    setLogs([]);
+    await runWorkflow({ nodes, edges }, (m) => setLogs((l) => [...l, m]));
+  };
+
+  return (
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <NodePalette />
+      <div style={{ flex: 1 }} ref={wrapperRef} onDrop={onDrop} onDragOver={onDragOver}>
+        <WorkflowCanvas
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onSelectionChange={onSelectionChange}
+        />
+      </div>
+      <NodeConfigPanel node={selected} onChange={updateNode} />
+      <div style={{ position: 'absolute', top: 10, right: 10, display: 'flex', gap: 8 }}>
+        <button onClick={handleExport}>Export</button>
+        <label style={{ cursor: 'pointer' }}>
+          Import
+          <input type="file" accept="application/json" style={{ display: 'none' }} onChange={handleImport} />
+        </label>
+        <button onClick={handleRun}>Run</button>
+      </div>
+      <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0 }}>
+        <ExecutionConsole logs={logs} />
+      </div>
+    </div>
+  );
+}
+
+export default function MCPWorkflowPage() {
+  return (
+    <ReactFlowProvider>
+      <WorkflowEditor />
+    </ReactFlowProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold React Flow-based workflow builder with draggable node palette and config panel
- add workflow serialization helpers and mock execution engine
- include example workflow data

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a52f3c4e3883239f42a397998dbe0c